### PR TITLE
Fully migrate to otel4s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.15, 2.13.8, 3.2.2]
+        scala: [2.12.18, 2.13.12, 3.3.1]
         java: [temurin@17]
-        project: [rootJS, rootJVM, rootNative]
+        project: [rootJVM]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -69,14 +69,6 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
 
-      - name: scalaJSLink
-        if: matrix.project == 'rootJS'
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' Test/scalaJSLinkerResult
-
-      - name: nativeLink
-        if: matrix.project == 'rootNative'
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' Test/nativeLink
-
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
@@ -90,11 +82,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p examples/target target .js/target core/.native/target site/target core/.js/target core/.jvm/target .jvm/target .native/target project/target
+        run: mkdir -p examples/target target .js/target site/target core/.jvm/target .jvm/target .native/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar examples/target target .js/target core/.native/target site/target core/.js/target core/.jvm/target .jvm/target .native/target project/target
+        run: tar cf targets.tar examples/target target .js/target site/target core/.jvm/target .jvm/target .native/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -110,7 +102,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.2.2]
+        scala: [3.3.1]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -147,92 +139,32 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (2.12.15, rootJS)
+      - name: Download target directories (2.12.18, rootJVM)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.18-rootJVM
 
-      - name: Inflate target directories (2.12.15, rootJS)
+      - name: Inflate target directories (2.12.18, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12.15, rootJVM)
+      - name: Download target directories (2.13.12, rootJVM)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.12-rootJVM
 
-      - name: Inflate target directories (2.12.15, rootJVM)
+      - name: Inflate target directories (2.13.12, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12.15, rootNative)
+      - name: Download target directories (3.3.1, rootJVM)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15-rootNative
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.1-rootJVM
 
-      - name: Inflate target directories (2.12.15, rootNative)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.13.8, rootJS)
-        uses: actions/download-artifact@v3
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-rootJS
-
-      - name: Inflate target directories (2.13.8, rootJS)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.13.8, rootJVM)
-        uses: actions/download-artifact@v3
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-rootJVM
-
-      - name: Inflate target directories (2.13.8, rootJVM)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.13.8, rootNative)
-        uses: actions/download-artifact@v3
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-rootNative
-
-      - name: Inflate target directories (2.13.8, rootNative)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3.2.2, rootJS)
-        uses: actions/download-artifact@v3
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.2-rootJS
-
-      - name: Inflate target directories (3.2.2, rootJS)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3.2.2, rootJVM)
-        uses: actions/download-artifact@v3
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.2-rootJVM
-
-      - name: Inflate target directories (3.2.2, rootJVM)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3.2.2, rootNative)
-        uses: actions/download-artifact@v3
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.2-rootNative
-
-      - name: Inflate target directories (3.2.2, rootNative)
+      - name: Inflate target directories (3.3.1, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -256,7 +188,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.2.2]
+        scala: [3.3.1]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.18, 2.13.12, 3.3.1]
+        scala: [2.13.12, 3.3.1]
         java: [temurin@17]
         project: [rootJVM]
     runs-on: ${{ matrix.os }}
@@ -138,16 +138,6 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
-
-      - name: Download target directories (2.12.18, rootJVM)
-        uses: actions/download-artifact@v3
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.18-rootJVM
-
-      - name: Inflate target directories (2.12.18, rootJVM)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
 
       - name: Download target directories (2.13.12, rootJVM)
         uses: actions/download-artifact@v3

--- a/build.sbt
+++ b/build.sbt
@@ -15,10 +15,9 @@ ThisBuild / tlCiReleaseBranches := Seq("main")
 // true by default, set to false to publish to s01.oss.sonatype.org
 ThisBuild / tlSonatypeUseLegacyHost := true
 
-val scala212 = "2.12.18"
 val scala213 = "2.13.12"
 val scala3 = "3.3.1"
-ThisBuild / crossScalaVersions := Seq(scala212, scala213, scala3)
+ThisBuild / crossScalaVersions := Seq(scala213, scala3)
 ThisBuild / scalaVersion := scala3
 
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))

--- a/build.sbt
+++ b/build.sbt
@@ -15,22 +15,25 @@ ThisBuild / tlCiReleaseBranches := Seq("main")
 // true by default, set to false to publish to s01.oss.sonatype.org
 ThisBuild / tlSonatypeUseLegacyHost := true
 
-ThisBuild / crossScalaVersions := Seq("2.12.15", "2.13.8", "3.2.2")
-ThisBuild / scalaVersion := "3.2.2"
+val scala212 = "2.12.18"
+val scala213 = "2.13.12"
+val scala3 = "3.3.1"
+ThisBuild / crossScalaVersions := Seq(scala212, scala213, scala3)
+ThisBuild / scalaVersion := scala3
 
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))
 ThisBuild / tlJdkRelease := Some(8)
 
 ThisBuild / testFrameworks += new TestFramework("munit.Framework")
 
-val catsV = "2.9.0"
-val catsEffectV = "3.4.9"
-val fs2V = "3.6.1"
-val http4sV = "0.23.18"
-val fiberLocalV = "0.1.2"
+val catsV = "2.10.0"
+val catsEffectV = "3.5.2"
+val catsMtlV = "1.3.1"
+val fs2V = "3.9.2"
+val http4sV = "0.23.23"
 
-val openTelemetryV = "1.22.0"
-val otel4sV = "0.2.1"
+val openTelemetryV = "1.31.0"
+val otel4sV = "0.3.0-RC1"
 
 val munitCatsEffectV = "2.0.0-M3"
 
@@ -61,9 +64,9 @@ lazy val core = crossProject(JVMPlatform)
       "org.http4s"                  %%% "http4s-server"        % http4sV,
       "org.http4s"                  %%% "http4s-client"        % http4sV,
 
-      "io.chrisdavenport"           %%% "fiberlocal"           % fiberLocalV,
-      "org.typelevel" %%% "otel4s-core-trace" % otel4sV,
-      "org.typelevel" %%% "cats-mtl" % "1.3.1",
+      "org.typelevel"               %%% "otel4s-core-trace" % otel4sV,
+      "org.typelevel"               %%% "otel4s-java"       % otel4sV,
+      "org.typelevel"               %%% "cats-mtl" % catsMtlV,
 
 
       "org.typelevel"               %%% "munit-cats-effect"        % munitCatsEffectV         % Test,
@@ -78,7 +81,7 @@ lazy val examples = project.in(file("examples"))
     libraryDependencies ++= Seq(
       "org.typelevel"    %% "otel4s-java" % otel4sV,
       "io.opentelemetry" % "opentelemetry-exporter-otlp" % openTelemetryV % Runtime,
-      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % s"${openTelemetryV}-alpha" % Runtime,
+      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % openTelemetryV % Runtime,
       "org.http4s"   %% "http4s-dsl"          % http4sV,
       "org.http4s"   %% "http4s-ember-server" % http4sV,
       "org.http4s"   %% "http4s-ember-client" % http4sV,

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ val fs2V = "3.9.2"
 val http4sV = "0.23.23"
 
 val openTelemetryV = "1.31.0"
-val otel4sV = "0.3.0-RC1"
+val otel4sV = "0.3.0-RC2"
 
 val munitCatsEffectV = "2.0.0-M3"
 

--- a/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/ExternalHelpers.scala
+++ b/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/ExternalHelpers.scala
@@ -1,16 +1,14 @@
 package io.chrisdavenport.natchezhttp4sotel
 
-import cats.syntax.all._
-import cats.effect._
+import cats.{Applicative, Functor}
+import cats.effect.{IOLocal, LiftIO, MonadCancelThrow}
 import cats.mtl.Local
-import cats._
-import org.typelevel.vault.Vault
+import cats.syntax.functor._
 
 object ExternalHelpers {
 
-  def localVault[F[_]: LiftIO: MonadCancelThrow]: F[Local[F, Vault]] = {
-    LiftIO[F].liftIO(IOLocal(Vault.empty)).map(localForIoLocal(_))
-  }
+  def local[F[_]: LiftIO: MonadCancelThrow, A](value: A): F[Local[F, A]] =
+    LiftIO[F].liftIO(IOLocal(value)).map(localForIoLocal(_))
 
   def localForIoLocal[F[_]: MonadCancelThrow: LiftIO, E](
       ioLocal: IOLocal[E]
@@ -25,6 +23,4 @@ object ExternalHelpers {
           fa
         )(ioLocal.set(_).to[F])
     }
-
-
 }

--- a/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/OTHttpTags.scala
+++ b/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/OTHttpTags.scala
@@ -6,7 +6,6 @@ import org.http4s.headers._
 import com.comcast.ip4s._
 import org.typelevel.ci.CIString
 import cats.syntax.all._
-import io.chrisdavenport.natchezhttp4sotel.helpers.printStackTrace
 // This follows the documents here
 // https://github.com/open-telemetry/opentelemetry-specification/blob/a50def370ef444029a12ea637769229768daeaf8/specification/trace/semantic_conventions/http.md
 // We can update both the link and the tags as standards develop out of experimental

--- a/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/helpers.scala
+++ b/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/helpers.scala
@@ -1,55 +1,25 @@
 package io.chrisdavenport.natchezhttp4sotel
 
-import org.typelevel.otel4s.trace.TracerProvider
-import org.typelevel.otel4s.TextMapGetter
+import cats.effect.MonadCancelThrow
+import cats.syntax.functor._
+import org.typelevel.otel4s.trace.{Tracer, TracerBuilder, TracerProvider}
+import org.typelevel.otel4s.KindTransformer
+
+import java.io.{OutputStream, FilterOutputStream, ByteArrayOutputStream, PrintStream}
+import scala.util.Using
 
 private[natchezhttp4sotel] object helpers {
+  def builderMapK[F[_]: MonadCancelThrow, G[_]: MonadCancelThrow](b: TracerBuilder[F])(implicit kt: KindTransformer[F, G]): TracerBuilder[G] =
+    new TracerBuilder[G] {
+      def withVersion(version: String): TracerBuilder[G] =
+        builderMapK[F, G](b.withVersion(version))
+      def withSchemaUrl(schemaUrl: String): TracerBuilder[G] =
+        builderMapK[F, G](b.withSchemaUrl(schemaUrl))
+      def get: G[Tracer[G]] = kt.liftK(b.get.map(_.mapK[G]))
+    }
 
-  implicit val textMapGetter: TextMapGetter[org.http4s.Headers] = new TextMapGetter[org.http4s.Headers] {
-
-    def get(carrier: org.http4s.Headers, key: String): Option[String] =
-      carrier.get(org.typelevel.ci.CIString(key)).map(_.head.value)
-    def keys(carrier: org.http4s.Headers): List[String] = carrier.headers.map(_.name.toString)
-  }
-
-
-  import org.typelevel.otel4s.trace.Tracer
-  import cats.data.OptionT
-
-  def liftImplicit[F[_]](tracer: Tracer[F]): Tracer[OptionT[F, *]] = new Tracer[OptionT[F, *]]{
-    /** As seen from class $anon, the missing signatures are as follows.
-    *  For convenience, these are usable as stub implementations.
-    */
-    def childScope[A]
-    (parent: org.typelevel.otel4s.trace.SpanContext)
-      (fa: cats.data.OptionT[F, A]): cats.data.OptionT[F, A] = ???
-    def currentSpanContext:
-    cats.data.OptionT[F, Option[org.typelevel.otel4s.trace.SpanContext]] = ???
-    def joinOrRoot[A, C]
-    (carrier: C)
-      (fa: cats.data.OptionT[F, A])
-        (implicit evidence$1: org.typelevel.otel4s.TextMapGetter[C]):
-          cats.data.OptionT[F, A] = ???
-    override def meta: org.typelevel.otel4s.trace.Tracer.Meta[cats.data.OptionT[F, *]] = ???
-    def noopScope[A](fa: cats.data.OptionT[F, A]): cats.data.OptionT[F, A] = ???
-    def rootScope[A](fa: cats.data.OptionT[F, A]): cats.data.OptionT[F, A] = ???
-    override def spanBuilder(name: String):org.typelevel.otel4s.trace.SpanBuilder.Aux[cats.data.OptionT[F, *],
-        org.typelevel.otel4s.trace.Span[cats.data.OptionT[F, *]]
-      ] = ???
-  }
-
-  def provider[F[_]](t: TracerProvider[F]): TracerProvider[OptionT[F, *]] = new TracerProvider[OptionT[F, *]] {
-    def tracer(name: String): org.typelevel.otel4s.trace.TracerBuilder[cats.data.OptionT[F,*]] = ???
-  }
-
-
-
-
-
-
-
-  import java.io.{OutputStream, FilterOutputStream, ByteArrayOutputStream, PrintStream}
-
+  def providerMapK[F[_]: MonadCancelThrow, G[_]: MonadCancelThrow](tp: TracerProvider[F])(implicit kt: KindTransformer[F, G]): TracerProvider[G] =
+    (name: String) => builderMapK(tp.tracer(name))
 
   def listStackTrace(e: Throwable): List[String] = {
     e.getStackTrace().toList.map(
@@ -59,12 +29,11 @@ private[natchezhttp4sotel] object helpers {
 
   def printStackTrace(e: Throwable): String = {
     val baos = new ByteArrayOutputStream
-    val fs   = new AnsiFilterStream(baos)
-    val ps   = new PrintStream(fs, true, "UTF-8")
-    e.printStackTrace(ps)
-    ps.close
-    fs.close
-    baos.close
+    Using.resource(new AnsiFilterStream(baos)) { fs =>
+      Using.resource(new PrintStream(fs, true, "UTF-8")) { ps =>
+        e.printStackTrace(ps)
+      }
+    }
     new String(baos.toByteArray, "UTF-8")
   }
 

--- a/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/helpers.scala
+++ b/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/helpers.scala
@@ -1,26 +1,9 @@
 package io.chrisdavenport.natchezhttp4sotel
 
-import cats.effect.MonadCancelThrow
-import cats.syntax.functor._
-import org.typelevel.otel4s.trace.{Tracer, TracerBuilder, TracerProvider}
-import org.typelevel.otel4s.KindTransformer
-
 import java.io.{OutputStream, FilterOutputStream, ByteArrayOutputStream, PrintStream}
 import scala.util.Using
 
 private[natchezhttp4sotel] object helpers {
-  def builderMapK[F[_]: MonadCancelThrow, G[_]: MonadCancelThrow](b: TracerBuilder[F])(implicit kt: KindTransformer[F, G]): TracerBuilder[G] =
-    new TracerBuilder[G] {
-      def withVersion(version: String): TracerBuilder[G] =
-        builderMapK[F, G](b.withVersion(version))
-      def withSchemaUrl(schemaUrl: String): TracerBuilder[G] =
-        builderMapK[F, G](b.withSchemaUrl(schemaUrl))
-      def get: G[Tracer[G]] = kt.liftK(b.get.map(_.mapK[G]))
-    }
-
-  def providerMapK[F[_]: MonadCancelThrow, G[_]: MonadCancelThrow](tp: TracerProvider[F])(implicit kt: KindTransformer[F, G]): TracerProvider[G] =
-    (name: String) => builderMapK(tp.tracer(name))
-
   def listStackTrace(e: Throwable): List[String] = {
     e.getStackTrace().toList.map(
       element => element.toString()

--- a/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/package.scala
@@ -1,10 +1,8 @@
 package io.chrisdavenport
 
-import cats.arrow.FunctionK
-import cats.~>
 import org.http4s.{Header, Headers}
 import org.typelevel.ci.CIString
-import org.typelevel.otel4s.{KindTransformer, TextMapGetter, TextMapUpdater}
+import org.typelevel.otel4s.{TextMapGetter, TextMapUpdater}
 
 package object natchezhttp4sotel {
   implicit val headersTMU: TextMapUpdater[Headers] =
@@ -15,12 +13,5 @@ package object natchezhttp4sotel {
         carrier.get(CIString(key)).map(_.head.value)
       def keys(carrier: Headers): Iterable[String] =
         carrier.headers.view.map(_.name).distinct.map(_.toString).toSeq
-    }
-
-  // TODO: remove after release of otel4s > 0.3.0-RC1
-  implicit def identityKindTransformer[F[_]]: KindTransformer[F, F] =
-    new KindTransformer[F, F] {
-      val liftK: F ~> F = FunctionK.id
-      def limitedMapK[A](ga: F[A])(f: F ~> F): F[A] = f(ga)
     }
 }

--- a/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/package.scala
+++ b/core/src/main/scala/io/chrisdavenport/natchezhttp4sotel/package.scala
@@ -1,0 +1,26 @@
+package io.chrisdavenport
+
+import cats.arrow.FunctionK
+import cats.~>
+import org.http4s.{Header, Headers}
+import org.typelevel.ci.CIString
+import org.typelevel.otel4s.{KindTransformer, TextMapGetter, TextMapUpdater}
+
+package object natchezhttp4sotel {
+  implicit val headersTMU: TextMapUpdater[Headers] =
+    (carrier: Headers, key: String, value: String) => carrier.put(Header.Raw(CIString(key), value))
+  implicit val headersTMG: TextMapGetter[Headers] =
+    new TextMapGetter[Headers] {
+      def get(carrier: Headers, key: String): Option[String] =
+        carrier.get(CIString(key)).map(_.head.value)
+      def keys(carrier: Headers): Iterable[String] =
+        carrier.headers.view.map(_.name).distinct.map(_.toString).toSeq
+    }
+
+  // TODO: remove after release of otel4s > 0.3.0-RC1
+  implicit def identityKindTransformer[F[_]]: KindTransformer[F, F] =
+    new KindTransformer[F, F] {
+      val liftK: F ~> F = FunctionK.id
+      def limitedMapK[A](ga: F[A])(f: F ~> F): F[A] = f(ga)
+    }
+}

--- a/examples/src/main/scala/example/Common.scala
+++ b/examples/src/main/scala/example/Common.scala
@@ -1,8 +1,9 @@
 package example
 
 import cats._
-import cats.effect.{ Trace => _, _ }
+import cats.effect.{Trace => _, _}
 import cats.syntax.all._
+import org.typelevel.otel4s.Attribute
 // import io.jaegertracing.Configuration.ReporterConfiguration
 // import io.jaegertracing.Configuration.SamplerConfiguration
 // import natchez._
@@ -18,11 +19,9 @@ trait Common {
 
   // A dumb subroutine that does some tracing
   def greet[F[_]: Monad: Tracer](input: String) =
-    Tracer[F].span("greet").surround {
+    Tracer[F].span("greet").use { span =>
       for {
-        // _ <- Tracer[F].put("input" -> input)
-        // How to append attributes to current span?
-        _ <- Applicative[F].unit
+        _ <- span.addAttribute(Attribute("input", input))
       } yield s"Hello $input!\n"
     }
 


### PR DESCRIPTION
Finish implementing all features of migration to otel4s, using otel4s version 0.3.0-RC2.

I did a bit of cleanup, but the code could probably still use a bit more, and some formatting besides.